### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ An INDEPENDENT fork of <a href="https://github.com/TeamNewPipe/NewPipe">NewPipe<
 * Search filters
 * Filter items in local playlists
 * Android 13 support
-* Musci player mode
+* Music player mode
 * Sort playlists
 * Remove duplicate items of local playlists
 * Open timestamp in the main player


### PR DESCRIPTION
Musci->Music  
I didn't notice it when making [this PR](https://codeberg.org/NullPointerException/PipePipe/pulls/47)  