### PR TITLE
feat: added swipe-to-delete from search history

### DIFF
--- a/android/src/main/kotlin/project/pipepipe/app/ui/screens/SearchScreen.kt
+++ b/android/src/main/kotlin/project/pipepipe/app/ui/screens/SearchScreen.kt
@@ -322,45 +322,57 @@ fun SearchScreen(
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.background)
                 ) {
-                    items(uiState.searchSuggestionList) { suggestion ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(40.dp)
-                                .clickable {
-                                    viewModel.updateSearchQuery(suggestion.text)
-                                    performSearch(suggestion.text)
-                                }
-                                .padding(horizontal = 16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                if (suggestion.isLocal)Icons.Default.History else Icons.Default.Search,
-                                contentDescription = if (suggestion.isLocal) stringResource(MR.strings.title_activity_history) else stringResource(MR.strings.search),
-                                modifier = Modifier.size(22.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                    itemsIndexed(
+                        items = uiState.searchSuggestionList,
+                        key = { i, suggestion -> suggestion.text + i }
+                    ) { _, suggestion ->
+                        val dismissState = rememberSwipeToDismissBoxState()
 
-                            Text(
-                                text = suggestion.text,
+                        SwipeToDismissBox(
+                            state = dismissState,
+                            backgroundContent = {},
+                            onDismiss = { viewModel.removeLocalSuggestion(suggestion.text) },
+                            gesturesEnabled = suggestion.isLocal
+                        ) {
+                            Row(
                                 modifier = Modifier
-                                    .weight(1f)
-                                    .padding(horizontal = 16.dp),
-                                fontSize = 13.5.sp,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            Icon(
-                                Icons.Default.NorthWest,
-                                contentDescription = stringResource(MR.strings.fill_search),
-                                modifier = Modifier
-                                    .size(21.dp)
+                                    .fillMaxWidth()
+                                    .height(40.dp)
                                     .clickable {
                                         viewModel.updateSearchQuery(suggestion.text)
-                                        focusRequester.requestFocus()
-                                    },
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                                        performSearch(suggestion.text)
+                                    }
+                                    .padding(horizontal = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    if (suggestion.isLocal) Icons.Default.History else Icons.Default.Search,
+                                    contentDescription = if (suggestion.isLocal) stringResource(MR.strings.title_activity_history) else stringResource(MR.strings.search),
+                                    modifier = Modifier.size(22.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+
+                                Text(
+                                    text = suggestion.text,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 16.dp),
+                                    fontSize = 13.5.sp,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Icon(
+                                    Icons.Default.NorthWest,
+                                    contentDescription = stringResource(MR.strings.fill_search),
+                                    modifier = Modifier
+                                        .size(21.dp)
+                                        .clickable {
+                                            viewModel.updateSearchQuery(suggestion.text)
+                                            focusRequester.requestFocus()
+                                        },
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
                     }
                 }

--- a/android/src/main/kotlin/project/pipepipe/app/ui/viewmodel/SearchViewModel.kt
+++ b/android/src/main/kotlin/project/pipepipe/app/ui/viewmodel/SearchViewModel.kt
@@ -42,6 +42,12 @@ class SearchViewModel : ViewModel() {
         }
     }
 
+    fun removeLocalSuggestion(suggestionText: String) {
+        viewModelScope.launch {
+            sharedViewModel.removeLocalSuggestion(suggestionText)
+        }
+    }
+
     fun updateSelectedService(service: SupportedServiceInfo) {
         sharedViewModel.updateSelectedService(service)
     }

--- a/library/src/commonMain/kotlin/project/pipepipe/app/viewmodel/SearchViewModel.kt
+++ b/library/src/commonMain/kotlin/project/pipepipe/app/viewmodel/SearchViewModel.kt
@@ -73,6 +73,21 @@ class SearchViewModel() : BaseViewModel<SearchUiState>(SearchUiState()) {
         }
     }
 
+    suspend fun removeLocalSuggestion(suggestionText: String) {
+        DatabaseOperations.getSearchHistory()
+            .find { it.search == suggestionText }?.let { removedSuggestion ->
+            val result = DatabaseOperations.deleteSearchHistory(removedSuggestion.id)
+
+            if (result.value == 1L) {
+                setState {
+                    it.copy(
+                        searchSuggestionList = it.searchSuggestionList.filterNot { suggestion -> suggestion.text == suggestionText }
+                    )
+                }
+            }
+        }
+    }
+
     fun updateSelectedService(service: SupportedServiceInfo) {
         if (service == uiState.value) {
             return


### PR DESCRIPTION
Added the ability to delete an item from the search history.
Implemented swipe‑to‑delete for an item, just like it worked before version 5.0.

---
I didn’t find any open issues for this functionality.