### PR TITLE
fix: FilterByChannelScreen using FitlerByKeyword title

### DIFF
--- a/android/src/main/kotlin/project/pipepipe/app/ui/screens/settings/FilterSettingScreen.kt
+++ b/android/src/main/kotlin/project/pipepipe/app/ui/screens/settings/FilterSettingScreen.kt
@@ -277,7 +277,8 @@ fun FilterByKeywordsScreen(
                         )
                     } else {
                         Text(
-                            stringResource(MR.strings.filter_by_keyword_title),
+                            if (isChannelSceen) stringResource(MR.strings.filter_by_channel_title)
+                                else stringResource(MR.strings.filter_by_keyword_title),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             fontWeight = FontWeight.Medium,


### PR DESCRIPTION
The filter by channels screen used the title "Filter by keywords".