### PR TITLE
docs: update PipePipe Wiki attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ko-fi: https://ko-fi.com/pipepipe
 
 ## Community
 
-[PipePipe Wiki](https://priveetee.github.io/Docs-PipePipe) User wiki maintained by [@Priveetee](https://github.com/Priveetee)
+[PipePipe Wiki](https://priveetee.github.io/Docs-PipePipe) maintained by [@Priveetee](https://github.com/Priveetee)
 
 ## Special Thanks
 


### PR DESCRIPTION
Small README update requested by @InfinityLoop1308 here:
https://github.com/InfinityLoop1308/PipePipeExtractor/pull/86#issuecomment-5014984833

This removes `User` from the PipePipe Wiki attribution.
